### PR TITLE
Fix wrong package name in install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Since v0.4 `node-iconv` is not included by default as a dependency. If you need 
 
 ## Installation
 
-    npm install mailparser
+    npm install mailparser-mit
 
 ## Usage
 


### PR DESCRIPTION
fix #4 

I just noticed [the patch](https://github.com/mazira/mailparser-mit/pull/3) submitted by @abrown28 hasn't been applied, so I'm re-submitting it.